### PR TITLE
Changed build.fsx to make WindowsAzure.Storage a Nuget dependency - Take 2

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -127,6 +127,7 @@ Target "Package"
                         "Microsoft.WindowsAzure.Configuration.dll"; "Microsoft.WindowsAzure.Storage.dll"; 
                         "Newtonsoft.Json.dll"; "System.Spatial.dll" ] 
                      |> List.map (fun file -> @"..\bin\" + file, Some "lib/net40", None))
+                    @ [ "StorageTypeProvider.fsx", None, None ]
                      }) 
         ("nuget/" + project + ".nuspec"))
 // --------------------------------------------------------------------------------------

--- a/build.fsx
+++ b/build.fsx
@@ -120,7 +120,7 @@ Target "Package"
                  Tags = tags
                  OutputPath = "bin"
                  Dependencies = ["WindowsAzure.Storage","4.3.0"]
-                 References = ["FSharp.Azure.StorageTypeProvider.xml"; "FSharp.Azure.StorageTypeProvider.dll"] 
+                 References = ["FSharp.Azure.StorageTypeProvider.dll"] 
                  Files = 
                      ([ "FSharp.Azure.StorageTypeProvider.xml"; "FSharp.Azure.StorageTypeProvider.dll"; "Microsoft.Data.Edm.dll"; 
                         "Microsoft.Data.OData.dll"; "Microsoft.Data.Services.Client.dll"; 

--- a/build.fsx
+++ b/build.fsx
@@ -127,7 +127,7 @@ Target "Package"
                         "Microsoft.WindowsAzure.Configuration.dll"; "Microsoft.WindowsAzure.Storage.dll"; 
                         "Newtonsoft.Json.dll"; "System.Spatial.dll" ] 
                      |> List.map (fun file -> @"..\bin\" + file, Some "lib/net40", None))
-                    @ [ "StorageTypeProvider.fsx", None, None ]
+                     @ [ "StorageTypeProvider.fsx", None, None ]
                      }) 
         ("nuget/" + project + ".nuspec"))
 // --------------------------------------------------------------------------------------

--- a/build.fsx
+++ b/build.fsx
@@ -119,11 +119,9 @@ Target "Package"
                  ReleaseNotes = release.Notes |> String.concat Environment.NewLine
                  Tags = tags
                  OutputPath = "bin"
+                 Dependencies = ["WindowsAzure.Storage","4.3.0"]
                  Files = 
-                     ([ "FSharp.Azure.StorageTypeProvider.xml"; "FSharp.Azure.StorageTypeProvider.dll"; 
-                        "Microsoft.Data.Edm.dll"; "Microsoft.Data.OData.dll"; "Microsoft.Data.Services.Client.dll"; 
-                        "Microsoft.WindowsAzure.Configuration.dll"; "Microsoft.WindowsAzure.Storage.dll"; 
-                        "Newtonsoft.Json.dll"; "System.Spatial.dll" ] 
+                     ([ "FSharp.Azure.StorageTypeProvider.xml"; "FSharp.Azure.StorageTypeProvider.dll" ] 
                      |> List.map (fun file -> @"..\bin\" + file, Some "lib/net40", None))
                      @ [ "StorageTypeProvider.fsx", None, None ]
                      }) 

--- a/build.fsx
+++ b/build.fsx
@@ -120,10 +120,13 @@ Target "Package"
                  Tags = tags
                  OutputPath = "bin"
                  Dependencies = ["WindowsAzure.Storage","4.3.0"]
+                 References = ["FSharp.Azure.StorageTypeProvider.xml"; "FSharp.Azure.StorageTypeProvider.dll"] 
                  Files = 
-                     ([ "FSharp.Azure.StorageTypeProvider.xml"; "FSharp.Azure.StorageTypeProvider.dll" ] 
+                     ([ "FSharp.Azure.StorageTypeProvider.xml"; "FSharp.Azure.StorageTypeProvider.dll"; "Microsoft.Data.Edm.dll"; 
+                        "Microsoft.Data.OData.dll"; "Microsoft.Data.Services.Client.dll"; 
+                        "Microsoft.WindowsAzure.Configuration.dll"; "Microsoft.WindowsAzure.Storage.dll"; 
+                        "Newtonsoft.Json.dll"; "System.Spatial.dll" ] 
                      |> List.map (fun file -> @"..\bin\" + file, Some "lib/net40", None))
-                     @ [ "StorageTypeProvider.fsx", None, None ]
                      }) 
         ("nuget/" + project + ".nuspec"))
 // --------------------------------------------------------------------------------------


### PR DESCRIPTION
It can be done,

by using nugets Reference spec http://docs.nuget.org/create/nuspec-reference#specifying-explicit-assembly-references we can bring the files over locally for the typeprovider to use but only reference dependent dlls from nuget.

Tested locally - works fine

fixes #51