### PR TITLE
Don't call Async.Start on downloadFolder

### DIFF
--- a/src/FSharp.Azure.StorageTypeProvider/Blob/BlobRepository.fs
+++ b/src/FSharp.Azure.StorageTypeProvider/Blob/BlobRepository.fs
@@ -71,4 +71,3 @@ let downloadFolder (connectionDetails, path) =
            downloadFile((connection,container,blob.Name),(Path.Combine(path, targetName))))
     |> Async.Parallel
     |> Async.Ignore
-    |> Async.Start


### PR DESCRIPTION
Fixes #58

 I just removed the call to `|> Async.Start` which works if the caller takes care of the `Async<unit>`.

Though as far as I understand, and I'm kind of new to this, that will be a change in behavior since `Async<'a>` in F# doesn't start until you explicitly run them, right? Would something like this be more correct?

``` fsharp
|> Async.StartChild
```

or

``` fsharp
|> Async.StartAsTask
|> Async.AwaitTask
```

I'm not too sure how someone would've used `Download(path)` predictably.