### PR TITLE
Add possibility to take connection string from configuration file

### DIFF
--- a/src/FSharp.Azure.StorageTypeProvider/Configuration.fs
+++ b/src/FSharp.Azure.StorageTypeProvider/Configuration.fs
@@ -1,0 +1,30 @@
+﻿namespace FSharp.Azure.StorageTypeProvider.Configuration
+
+open System.Configuration
+open System.IO
+open System.Collections.Generic
+
+type Configuration() =    
+    static member ReadConnectionStringFromConfigFileByName(name: string, resolutionFolder, fileName) =
+
+        let configFilename = 
+            if fileName <> "" 
+            then
+                let path = Path.Combine(resolutionFolder, fileName)
+                if not <| File.Exists path 
+                then raise <| FileNotFoundException( sprintf "Could not find config file '%s'." path)
+                else path
+            else
+                let appConfig = Path.Combine(resolutionFolder, "app.config")
+                let webConfig = Path.Combine(resolutionFolder, "web.config")
+
+                if File.Exists appConfig then appConfig
+                elif File.Exists webConfig then webConfig
+                else failwithf "Cannot find either app.config or web.config."
+        
+        let map = ExeConfigurationFileMap()
+        map.ExeConfigFilename <- configFilename
+        let configSection = ConfigurationManager.OpenMappedExeConfiguration(map, ConfigurationUserLevel.None).ConnectionStrings.ConnectionStrings
+        match configSection, lazy configSection.[name] with
+        | null, _ | _, Lazy null -> raise <| KeyNotFoundException(message = sprintf "Cannot find name %s in <connectionStrings> section of %s file." name configFilename)
+        | _, Lazy x -> x.ConnectionString

--- a/src/FSharp.Azure.StorageTypeProvider/FSharp.Azure.StorageTypeProvider.fsproj
+++ b/src/FSharp.Azure.StorageTypeProvider/FSharp.Azure.StorageTypeProvider.fsproj
@@ -64,6 +64,7 @@
       <Link>paket-files/DebugProvidedTypes.fs</Link>
     </Compile>
     <Compile Include="Shared.fs" />
+    <Compile Include="Configuration.fs" />
     <Compile Include="Table\SharedTableTypes.fs" />
     <Compile Include="Table\TableRepository.fs" />
     <Compile Include="Table\ProvidedTableTypes.fs" />
@@ -86,6 +87,7 @@
     </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Data.Services.Client" />


### PR DESCRIPTION
I was using this package the other day with the storage emulator when I was developing on my local computer. When I deployed it to azure however the build failed because the build server was not running the storage emulator and thus no types could be provided.

So I thought that it would probably be nice to have the ability to take the connectionstring from app.config/web.config instead of having to have it as a hardcoded literal in the code.

I ported some code from FSharp.Data.SqlClient for doing this.