### PR TITLE
Removed ref to Micorsoft.WindowsAzure.Configuration.dll in StorageTyp…

### DIFF
--- a/nuget/StorageTypeProvider.fsx
+++ b/nuget/StorageTypeProvider.fsx
@@ -5,7 +5,6 @@
 #r "Microsoft.Data.Edm.dll"
 #r "System.Spatial.dll"
 #r "Newtonsoft.Json.dll"
-#r "Microsoft.WindowsAzure.Configuration.dll"
 #r "Microsoft.WindowsAzure.Storage.dll"
 #r "System.Xml.Linq.dll"
 #r "FSharp.Azure.StorageTypeProvider.dll"


### PR DESCRIPTION
StorageTypeProvider.fsx in the Nuget package has a ref to Micorsoft.WindowsAzure.Configuration.dll which is not included in the Nuget lib and is unused as far as I can tell.