### PR TITLE
Proposed resolution for issue #19

### DIFF
--- a/src/FSharp.Azure.StorageTypeProvider/AzureTypeProvider.fs
+++ b/src/FSharp.Azure.StorageTypeProvider/AzureTypeProvider.fs
@@ -56,7 +56,7 @@ type public AzureTypeProvider(config : TypeProviderConfig) as this =
                    QueueMemberFactory.getQueueStorageMembers ]
                 |> List.map (fun builder -> builder(connectionString, domainTypes)))
             typeProviderForAccount
-        | Failure(ex) -> failwith (sprintf "Unable to validate connection string (%s)" ex.Message)
+        | Failure ex -> failwith (sprintf "Unable to validate connection string (%s)" ex.Message)
     
     // Parameterising the provider
     let parameters = 

--- a/src/FSharp.Azure.StorageTypeProvider/Table/ProvidedTableTypes.fs
+++ b/src/FSharp.Azure.StorageTypeProvider/Table/ProvidedTableTypes.fs
@@ -50,6 +50,17 @@ type AzureTable internal (defaultConnection, tableName) =
                let Partition(partitionKey), Row(rowKey) = entityId
                DynamicTableEntity(partitionKey, rowKey, ETag = "*"))
         |> executeBatchOperation TableOperation.Delete table
+
+    /// Deletes an entire partition from the table
+    member __.DeletePartition(partitionKey, ?connectionString) = 
+        let table = getTableForConnection (defaultArg connectionString defaultConnection)
+        let filter = Table.TableQuery.GenerateFilterCondition ("PartitionKey", Table.QueryComparisons.Equal, partitionKey)
+        let projection = [|"RowKey"|]
+        (new Table.TableQuery<Table.DynamicTableEntity>()).Where(filter).Select(projection)
+        |> table.ExecuteQuery
+        |> Seq.map(fun e -> (Partition(e.PartitionKey), Row(e.RowKey)))
+        |> __.Delete
+        |> ignore
     
     /// Gets the name of the table.
     member __.Name = tableName

--- a/src/FSharp.Azure.StorageTypeProvider/Table/TableMemberFactory.fs
+++ b/src/FSharp.Azure.StorageTypeProvider/Table/TableMemberFactory.fs
@@ -18,10 +18,10 @@ let getTableStorageMembers (connectionString, domainType : ProvidedTypeDefinitio
         tableProp
 
     let tableListingType = ProvidedTypeDefinition("Tables", Some typeof<obj>, HideObjectMethods = true)
-    tableListingType.AddMembersDelayed(fun _ -> 
-        getTables connectionString
-        |> Seq.map (createTableType connectionString)
-        |> Seq.toList)
+    getTables connectionString
+    |> Seq.map (createTableType connectionString)
+    |> Seq.toList
+    |> tableListingType.AddMembers
     
     let ctcProp = ProvidedProperty("CloudTableClient", typeof<CloudTableClient>, GetterCode = (fun _ -> <@@ TableBuilder.createAzureTableRoot connectionString @@>))
     ctcProp.AddXmlDoc "Gets a handle to the Table Azure SDK client for this storage account."

--- a/tests/IntegrationTests/TableUnitTests.fs
+++ b/tests/IntegrationTests/TableUnitTests.fs
@@ -166,3 +166,9 @@ let ``Cloud Table Client relates to the same data as the type provider``() =
      |> Seq.map(fun c -> c.Name)
      |> Set.ofSeq
      |> Set.contains "employee") =! true
+
+[<Fact>]
+[<ResetTableData>]
+let ``DeletePartition deletes entries with given partition key``() =
+    table.DeletePartition "men"
+    Assert.Equal (0,table.Query().``Where Partition Key Is``.``Equal To``("men").Execute().Length)


### PR DESCRIPTION
I think this resolves the issue without having to worry about continuation tokens/etags. 

The Azure SDK seems to split it up into segmented queries when we call `.Execute()` in [this class](https://github.com/Azure/azure-storage-net/blob/master/Lib/WindowsRuntime/Table/TableQuery.cs):


    internal IEnumerable<DynamicTableEntity> Execute(CloudTableClient client, string tableName,     TableRequestOptions requestOptions, OperationContext operationContext)
        {
            CommonUtility.AssertNotNullOrEmpty("tableName", tableName);
            TableRequestOptions modifiedOptions = TableRequestOptions.ApplyDefaults(requestOptions, client);
            operationContext = operationContext ?? new OperationContext();

            IEnumerable<DynamicTableEntity> enumerable =
                CommonUtility.LazyEnumerable<DynamicTableEntity>(
                (continuationToken) =>
                {
                    Task<TableQuerySegment> task = Task.Run(() => this.ExecuteQuerySegmentedAsync((TableContinuationToken)continuationToken, client, tableName, modifiedOptions, operationContext));
                    task.Wait();

                    TableQuerySegment seg = task.Result;

                    return new ResultSegment<DynamicTableEntity>((List<DynamicTableEntity>)seg.Results) { ContinuationToken = seg.ContinuationToken };
                },
                this.takeCount.HasValue ? this.takeCount.Value : long.MaxValue);

            return enumerable;
        }

I wasn't 100% confident on my navigation of the SDK source so I double checked by temporarily adding an integration test to insert 10,000 rows into a partition and confirm they had been deleted after calling the proposed new function. The test worked as expected (albeit slowly). I have not added this test to the main branch because it slowed down the integration tests but you can see the approach here: https://github.com/stewart-r/AzureStorageTypeProvider/tree/delete-partition

This [blog](http://www.wintellect.com/devcenter/jlane/deleting-entities-in-windows-azure-table-storage) seems to imply it is an inherently slow operation.  I can switch to using the approach in the blog and test the batch-size to try to trim down the time if you think it would be worthwhile?

(sorry about that git spaghetti - I got rid of the erroneously included files in the end but at the expense of an armada of commits I am now scared to try to squash/rebase! :-)  It only appears as a single commit in the main repo if the pull requested is accepted, right?).