### PR TITLE
Added test for multi-batch table query

### DIFF
--- a/tests/IntegrationTests/TableUnitTests.fs
+++ b/tests/IntegrationTests/TableUnitTests.fs
@@ -185,6 +185,18 @@ let ``Inserts many rows asyncronously using provided types correctly``() =
 
 [<Fact>]
 [<ResetTableData>]
+let ``Query with multiple batches returns all results``() =
+    [|1 .. 1001|]
+    |> Array.map(fun i -> sprintf "Row %i" i)
+    |> Array.map(fun i -> Local.Domain.employeeEntity(Partition "bulk insert", Row i, DateTime.MaxValue, true, "Hello", 100.0, 10 ))
+    |> table.Insert
+    |> ignore
+
+    let retrievedEntries = table.GetPartitionAsync("bulk insert") |> Async.RunSynchronously
+    test <@ retrievedEntries.Length = 1001 @>
+
+[<Fact>]
+[<ResetTableData>]
 let ``Query without arguments brings back all rows``() =
     test <@ table.Query().Execute().Length = 5 @>
 


### PR DESCRIPTION
As discussed.

This test fails for the code as I had it previously with the error in it (only returning the 1st 1000 rows) but passes with the code as it is now with the correction.