### PR TITLE
Fix exception on Delete called with empty collection

### DIFF
--- a/src/FSharp.Azure.StorageTypeProvider/Table/TableRepository.fs
+++ b/src/FSharp.Azure.StorageTypeProvider/Table/TableRepository.fs
@@ -135,17 +135,20 @@ let private batch size source =
         | head::tail -> doBatch output (head::currentBatch) (counter + 1) tail
     doBatch [] [] 0 (source |> Seq.toList)
 
-let private splitIntoBatches createTableOp entities = 
-    let batchSize = entities |> Seq.head |> BatchCalculator.getBatchSize
-    entities
-    |> Seq.groupBy(fun (entity:DynamicTableEntity) -> entity.PartitionKey)
-    |> Seq.collect(fun (partitionKey, entities) -> 
-           entities
-           |> batch batchSize
-           |> Seq.map(fun entityBatch ->
-                let batchForPartition = TableBatchOperation()
-                entityBatch |> Seq.iter (createTableOp >> batchForPartition.Add)
-                partitionKey, entityBatch, batchForPartition))
+let private splitIntoBatches createTableOp entities =
+    match entities with
+    | entities when Seq.isEmpty entities -> Seq.empty
+    | entities -> 
+        let batchSize = entities |> Seq.head |> BatchCalculator.getBatchSize
+        entities
+        |> Seq.groupBy(fun (entity:DynamicTableEntity) -> entity.PartitionKey)
+        |> Seq.collect(fun (partitionKey, entities) -> 
+                entities
+                |> batch batchSize
+                |> Seq.map(fun entityBatch ->
+                    let batchForPartition = TableBatchOperation()
+                    entityBatch |> Seq.iter (createTableOp >> batchForPartition.Add)
+                    partitionKey, entityBatch, batchForPartition))
 
 let private processErrorResp entityBatch buildEntityId (ex:StorageException) =
     let requestInformation = ex.RequestInformation

--- a/tests/IntegrationTests/TableUnitTests.fs
+++ b/tests/IntegrationTests/TableUnitTests.fs
@@ -55,6 +55,10 @@ let ``Non matching row key returns None``() =
     test <@ table.Get(Row "random", Partition "fred") = None @>
 
 [<Fact>]
+let ``Delete called with empty entitites sequnce should not throw``() =
+     table.Delete []
+
+[<Fact>]
 [<ResetTableData>]
 let ``Gets all rows in a table``() =
     test <@ table.Query().Execute().Length = 5 @>


### PR DESCRIPTION
Fixes #86 

Added test for the situation and fixed it on the splitIntoBatches function level. After my modification splitIntoBatches handles empty entity collections by immediately  returning empty sequence. 