### PR TITLE
Metrics Tables support

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -263,6 +263,7 @@ FinalTarget "PublishTestsResultsToAppveyor" (fun _ ->
 // Run all targets by default. Invoke 'build <Target>' to override
 
 Target "All" DoNothing
+Target "PackageAfterTest" DoNothing
 
 "Clean"
   ==> "AssemblyInfo"
@@ -270,8 +271,12 @@ Target "All" DoNothing
   ==> "ResetTestData"
   ==> "RunTests"
 
+"Build"
+  ==> "Nuget"
+  ==> "PackageAfterTest"
+
 "RunTests"
-  ==> "NuGet"
+  ==> "PackageAfterTest"
   =?> ("LocalDeploy", buildServer = LocalBuild)
   =?> ("BuildServerDeploy", buildServer = AppVeyor)
   ==> "BuildPackage"

--- a/src/FSharp.Azure.StorageTypeProvider/FSharp.Azure.StorageTypeProvider.fsproj
+++ b/src/FSharp.Azure.StorageTypeProvider/FSharp.Azure.StorageTypeProvider.fsproj
@@ -28,6 +28,44 @@
     <WarningLevel>3</WarningLevel>
     <DocumentationFile>..\..\bin\FSharp.Azure.StorageTypeProvider.XML</DocumentationFile>
   </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\..\paket-files\fsprojects\FSharp.TypeProviders.StarterPack\src\ProvidedTypes.fsi">
+      <Paket>True</Paket>
+      <Link>paket-files/ProvidedTypes.fsi</Link>
+    </Compile>
+    <Compile Include="..\..\paket-files\fsprojects\FSharp.TypeProviders.StarterPack\src\ProvidedTypes.fs">
+      <Paket>True</Paket>
+      <Link>paket-files/ProvidedTypes.fs</Link>
+    </Compile>
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Data.Services.Client" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Shared.fs" />
+    <Compile Include="Configuration.fs" />
+    <Compile Include="Table/SharedTableTypes.fs" />
+    <Compile Include="Table/TableRepository.fs" />
+    <Compile Include="Table/ProvidedTableTypes.fs" />
+    <Compile Include="Table/TableQueryBuilder.fs" />
+    <Compile Include="Table/TableEntityMemberFactory.fs" />
+    <Compile Include="Table/TableMemberFactory.fs" />
+    <Compile Include="Blob/BlobRepository.fs" />
+    <Compile Include="Blob/ProvidedBlobTypes.fs" />
+    <Compile Include="Blob/BlobMemberFactory.fs" />
+    <Compile Include="Queue/QueueRepository.fs" />
+    <Compile Include="Queue/ProvidedQueueTypes.fs" />
+    <Compile Include="Queue/QueueMemberFactory.fs" />
+    <Compile Include="AzureTypeProvider.fs" />
+    <None Include="App.config" />
+    <Content Include="paket.references" />
+  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '11.0'">
@@ -302,42 +340,4 @@
       </ItemGroup>
     </When>
   </Choose>
-  <ItemGroup>
-    <Compile Include="..\..\paket-files\fsprojects\FSharp.TypeProviders.StarterPack\src\ProvidedTypes.fsi">
-      <Paket>True</Paket>
-      <Link>paket-files/ProvidedTypes.fsi</Link>
-    </Compile>
-    <Compile Include="..\..\paket-files\fsprojects\FSharp.TypeProviders.StarterPack\src\ProvidedTypes.fs">
-      <Paket>True</Paket>
-      <Link>paket-files/ProvidedTypes.fs</Link>
-    </Compile>
-    <Compile Include="Shared.fs" />
-    <Compile Include="Configuration.fs" />
-    <Compile Include="Table/SharedTableTypes.fs" />
-    <Compile Include="Table/TableRepository.fs" />
-    <Compile Include="Table/ProvidedTableTypes.fs" />
-    <Compile Include="Table/TableQueryBuilder.fs" />
-    <Compile Include="Table/TableEntityMemberFactory.fs" />
-    <Compile Include="Table/TableMemberFactory.fs" />
-    <Compile Include="Blob/BlobRepository.fs" />
-    <Compile Include="Blob/ProvidedBlobTypes.fs" />
-    <Compile Include="Blob/BlobMemberFactory.fs" />
-    <Compile Include="Queue/QueueRepository.fs" />
-    <Compile Include="Queue/ProvidedQueueTypes.fs" />
-    <Compile Include="Queue/QueueMemberFactory.fs" />
-    <Compile Include="AzureTypeProvider.fs" />
-    <None Include="App.config" />
-    <Content Include="paket.references" />
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="mscorlib" />
-    <Reference Include="System" />
-    <Reference Include="System.Configuration" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Data.Services.Client" />
-    <Reference Include="System.Numerics" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Xml.Linq" />
-  </ItemGroup>
 </Project>

--- a/src/FSharp.Azure.StorageTypeProvider/FSharp.Azure.StorageTypeProvider.fsproj
+++ b/src/FSharp.Azure.StorageTypeProvider/FSharp.Azure.StorageTypeProvider.fsproj
@@ -28,44 +28,6 @@
     <WarningLevel>3</WarningLevel>
     <DocumentationFile>..\..\bin\FSharp.Azure.StorageTypeProvider.XML</DocumentationFile>
   </PropertyGroup>
-  <ItemGroup>
-    <Compile Include="..\..\paket-files\fsprojects\FSharp.TypeProviders.StarterPack\src\ProvidedTypes.fsi">
-      <Paket>True</Paket>
-      <Link>paket-files/ProvidedTypes.fsi</Link>
-    </Compile>
-    <Compile Include="..\..\paket-files\fsprojects\FSharp.TypeProviders.StarterPack\src\ProvidedTypes.fs">
-      <Paket>True</Paket>
-      <Link>paket-files/ProvidedTypes.fs</Link>
-    </Compile>
-    <Reference Include="mscorlib" />
-    <Reference Include="System" />
-    <Reference Include="System.Configuration" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Data.Services.Client" />
-    <Reference Include="System.Numerics" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Xml.Linq" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Shared.fs" />
-    <Compile Include="Configuration.fs" />
-    <Compile Include="Table/SharedTableTypes.fs" />
-    <Compile Include="Table/TableRepository.fs" />
-    <Compile Include="Table/ProvidedTableTypes.fs" />
-    <Compile Include="Table/TableQueryBuilder.fs" />
-    <Compile Include="Table/TableEntityMemberFactory.fs" />
-    <Compile Include="Table/TableMemberFactory.fs" />
-    <Compile Include="Blob/BlobRepository.fs" />
-    <Compile Include="Blob/ProvidedBlobTypes.fs" />
-    <Compile Include="Blob/BlobMemberFactory.fs" />
-    <Compile Include="Queue/QueueRepository.fs" />
-    <Compile Include="Queue/ProvidedQueueTypes.fs" />
-    <Compile Include="Queue/QueueMemberFactory.fs" />
-    <Compile Include="AzureTypeProvider.fs" />
-    <None Include="App.config" />
-    <Content Include="paket.references" />
-  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '11.0'">
@@ -340,4 +302,42 @@
       </ItemGroup>
     </When>
   </Choose>
+  <ItemGroup>
+    <Compile Include="..\..\paket-files\fsprojects\FSharp.TypeProviders.StarterPack\src\ProvidedTypes.fsi">
+      <Paket>True</Paket>
+      <Link>paket-files/ProvidedTypes.fsi</Link>
+    </Compile>
+    <Compile Include="..\..\paket-files\fsprojects\FSharp.TypeProviders.StarterPack\src\ProvidedTypes.fs">
+      <Paket>True</Paket>
+      <Link>paket-files/ProvidedTypes.fs</Link>
+    </Compile>
+    <Compile Include="Shared.fs" />
+    <Compile Include="Configuration.fs" />
+    <Compile Include="Table/SharedTableTypes.fs" />
+    <Compile Include="Table/TableRepository.fs" />
+    <Compile Include="Table/ProvidedTableTypes.fs" />
+    <Compile Include="Table/TableQueryBuilder.fs" />
+    <Compile Include="Table/TableEntityMemberFactory.fs" />
+    <Compile Include="Table/TableMemberFactory.fs" />
+    <Compile Include="Blob/BlobRepository.fs" />
+    <Compile Include="Blob/ProvidedBlobTypes.fs" />
+    <Compile Include="Blob/BlobMemberFactory.fs" />
+    <Compile Include="Queue/QueueRepository.fs" />
+    <Compile Include="Queue/ProvidedQueueTypes.fs" />
+    <Compile Include="Queue/QueueMemberFactory.fs" />
+    <Compile Include="AzureTypeProvider.fs" />
+    <None Include="App.config" />
+    <Content Include="paket.references" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Data.Services.Client" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
+  </ItemGroup>
 </Project>

--- a/src/FSharp.Azure.StorageTypeProvider/Table/TableMemberFactory.fs
+++ b/src/FSharp.Azure.StorageTypeProvider/Table/TableMemberFactory.fs
@@ -1,33 +1,50 @@
 ﻿module internal FSharp.Azure.StorageTypeProvider.Table.TableMemberFactory
 
 open FSharp.Azure.StorageTypeProvider.Table.TableRepository
-open Microsoft.WindowsAzure.Storage
 open Microsoft.WindowsAzure.Storage.Table
 open ProviderImplementation.ProvidedTypes
 
 /// Builds up the Table Storage member
-let getTableStorageMembers schemaInferenceRowCount (connectionString, domainType : ProvidedTypeDefinition) =     
+let getTableStorageMembers schemaInferenceRowCount (connectionString, domainType : ProvidedTypeDefinition) =
     /// Creates an individual Table member
-    let createTableType connectionString tableName = 
+    let createTableType connectionString tableName propertyName = 
         let tableEntityType = ProvidedTypeDefinition(tableName + "Entity", Some typeof<LightweightTableEntity>, HideObjectMethods = true)
         let tableType = ProvidedTypeDefinition(tableName + "Table", Some typeof<AzureTable>, HideObjectMethods = true)
         domainType.AddMembers [ tableEntityType; tableType ]
         TableEntityMemberFactory.buildTableEntityMembers schemaInferenceRowCount (tableType, tableEntityType, domainType, connectionString, tableName)
-        let tableProp = ProvidedProperty(tableName, tableType, GetterCode = (fun _ -> <@@ TableBuilder.createAzureTable connectionString tableName @@>))
+        let tableProp = ProvidedProperty(propertyName, tableType, GetterCode = (fun _ -> <@@ TableBuilder.createAzureTable connectionString tableName @@>))
         tableProp.AddXmlDoc <| sprintf "Provides access to the '%s' table." tableName
         tableProp
 
     let tableListingType = ProvidedTypeDefinition("Tables", Some typeof<obj>, HideObjectMethods = true)
+    domainType.AddMember tableListingType
+    
     getTables connectionString
-    |> Seq.map (createTableType connectionString)
+    |> Seq.map (fun table -> createTableType connectionString table table)
     |> Seq.toList
     |> tableListingType.AddMembers
-    
+
+    // Get any metrics tables that are available
+    match getMetricsTables connectionString with
+    | metrics when metrics = Seq.empty -> ()
+    | metrics ->
+        let metricsTablesType = ProvidedTypeDefinition("Metrics", Some typeof<obj>, HideObjectMethods = true)
+        domainType.AddMember metricsTablesType
+
+        for (period, locations) in metrics do
+            for (location, services) in locations do
+                for (service, tableName) in services do
+                    createTableType connectionString tableName (sprintf "%s %s metrics (%s)" period service location)
+                    |> metricsTablesType.AddMember
+
+        let metricsTablesProp = ProvidedProperty("Metrics", metricsTablesType, GetterCode = (fun _ -> <@@ () @@>))
+        metricsTablesProp.AddXmlDoc "Provides access to metrics tables populated by Azure that are available on this storage account."
+        tableListingType.AddMember metricsTablesProp
+
     let ctcProp = ProvidedProperty("CloudTableClient", typeof<CloudTableClient>, GetterCode = (fun _ -> <@@ TableBuilder.createAzureTableRoot connectionString @@>))
     ctcProp.AddXmlDoc "Gets a handle to the Table Azure SDK client for this storage account."
-    tableListingType.AddMember(ctcProp)
-    
-    domainType.AddMember tableListingType
+    tableListingType.AddMember ctcProp
+      
     let tableListingProp = ProvidedProperty("Tables", tableListingType, IsStatic = true, GetterCode = (fun _ -> <@@ () @@>))
     tableListingProp.AddXmlDoc "Gets the list of all tables in this storage account."
     tableListingProp

--- a/src/FSharp.Azure.StorageTypeProvider/Table/TableRepository.fs
+++ b/src/FSharp.Azure.StorageTypeProvider/Table/TableRepository.fs
@@ -78,16 +78,11 @@ let internal getMetricsTables connection =
 
     seq {
         for (description, period) in periods do
-            yield description, seq { 
-                for location in locations do
-                    yield location, seq {
-                        for service in services do
-                            let tableName = sprintf "$Metrics%s%sTransactions%s" period location service
-                            if (client.GetTableReference(tableName).Exists()) then
-                                yield service, tableName
-                    }
-            }
-    }
+            for location in locations do
+                for service in services do
+                    let tableName = sprintf "$Metrics%s%sTransactions%s" period location service
+                    if (client.GetTableReference(tableName).Exists()) then
+                        yield description, location, service, tableName }
 
 type private DynamicQuery = TableQuery<DynamicTableEntity>
 

--- a/src/FSharp.Azure.StorageTypeProvider/Table/TableRepository.fs
+++ b/src/FSharp.Azure.StorageTypeProvider/Table/TableRepository.fs
@@ -70,6 +70,25 @@ let internal getTables connection =
     let client = getTableClient connection
     client.ListTables() |> Seq.map(fun table -> table.Name)
 
+let internal getMetricsTables connection =
+    let client = getTableClient connection
+    let services = [ "Blob"; "Queue"; "Table"; "File" ]
+    let locations = [ "Primary"; "Secondary" ]
+    let periods = [ "Hourly", "Hour"; "Per Minute", "Minute" ]
+
+    seq {
+        for (description, period) in periods do
+            yield description, seq { 
+                for location in locations do
+                    yield location, seq {
+                        for service in services do
+                            let tableName = sprintf "$Metrics%s%sTransactions%s" period location service
+                            if (client.GetTableReference(tableName).Exists()) then
+                                yield service, tableName
+                    }
+            }
+    }
+
 type private DynamicQuery = TableQuery<DynamicTableEntity>
 
 let internal getRowsForSchema (rowCount: int) connection tableName = 


### PR DESCRIPTION
Can someone give this a bash - it should expose Blob / Queue / File / Table metrics tables that up until now were not exposed by the TP.

Rather than use the standard ``$table`` convention for the tables I've given the tables some nicer names and put them in a dedicated nested Metrics element within the Tables types.