### PR TITLE
More flexible JSON parsing and more concise table schema

### DIFF
--- a/src/FSharp.Azure.StorageTypeProvider/Shared.fs
+++ b/src/FSharp.Azure.StorageTypeProvider/Shared.fs
@@ -26,3 +26,43 @@ module Async =
         async {
             let! result = workflow
             return mapper result }
+
+///[omit]
+[<RequireQualifiedAccess>]
+[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+module Json =
+    open Newtonsoft.Json.Linq
+
+    type Json =
+        | String of string
+        | Number of decimal
+        | Boolean of bool
+        | Object of (string * Json)[]
+        | Array of Json[]
+        | Null  
+        member this.AsString = match this with Json.String s -> s | _ -> failwith "Not a string"
+        member this.AsNumber = match this with Json.Number s -> s | _ -> failwith "Not a number"
+        member this.AsBoolean = match this with Json.Boolean b -> b | _ -> failwith "Not a boolean"
+        member this.AsObject = match this with Json.Object o -> o | _ -> failwith "Not an object"
+        member this.AsArray = match this with Json.Array o -> o | _ -> failwith "Not an array"
+        member this.GetProperty key = this.AsObject |> Array.find (fst >> (=) key) |> snd
+        member this.TryGetProperty key =
+            match this with Json.Object o -> Some o | _ -> None
+            |> Option.bind (Array.tryFind (fst >> (=) key))
+            |> Option.map snd
+
+    let rec ofJToken (jToken:JToken) =
+        match jToken with
+        | :? JValue as v ->
+            match v.Value with
+            | :? string as s -> Json.String s
+            | :? decimal as d -> Json.Number (decimal d)
+            | :? int64 as i -> Json.Number (decimal i)
+            | :? int32 as i -> Json.Number (decimal i)
+            | :? float as f -> Json.Number (decimal f)
+            | :? bool as b -> Json.Boolean b
+            | null -> Json.Null
+            | v -> failwithf "Cannot convert JSON value type %s" (v.GetType().FullName)
+        | :? JObject as o -> o.Properties() |> Seq.map (fun p -> p.Name, ofJToken p.Value) |> Seq.toArray |> Json.Object
+        | :? JArray as a -> a.Values() |> Seq.map ofJToken |> Seq.toArray |> Json.Array
+        | v -> failwithf "Cannot convert JSON type %s" (v.GetType().FullName)

--- a/table-schema.json
+++ b/table-schema.json
@@ -1,23 +1,15 @@
 {
-    "tables": [
-        {
-            "table": "MyTable",
-            "columns": [
-                {
-                    "Column": "ColumnA",
-                    "Type": "String",
-                    "Optional": true
-                },
-                {
-                    "Column": "ColumnB",
-                    "Type": "DateTime",
-                    "Optional": true
-                },
-                {
-                    "Column": "ColumnC",
-                    "Type": "Boolean"
-                }
-            ]
+    "MyTable": {
+        "ColumnA": {
+            "Type": "String",
+            "Optional": true
+        },
+        "ColumnB": {
+            "Type": "DateTime",
+            "Optional": true
+        },
+        "ColumnC": {
+            "Type": "Boolean"
         }
-    ]
+    }
 }

--- a/tests/IntegrationTests/TableSchema.json
+++ b/tests/IntegrationTests/TableSchema.json
@@ -1,36 +1,23 @@
 ﻿{
-    "tables": [
-        {
-            "table": "MyTable",
-            "columns": [
-                {
-                    "Column": "ColumnA",
-                    "Type": "String",
-                    "Optional": true
-                },
-                {
-                    "Column": "ColumnB",
-                    "Type": "DateTime",
-                    "Optional": true
-                },
-                {
-                    "Column": "ColumnC",
-                    "Type": "Boolean"
-                }
-            ]
+    "MyTable": {
+        "ColumnA": {
+            "Type": "String",
+            "Optional": true
         },
-        {
-            "table": "YourTable",
-            "columns": [
-                {
-                    "Column": "ColumnA",
-                    "Type": "String"
-                },
-                {
-                    "Column": "ColumnB",
-                    "Type": "DateTime"
-                }
-            ]
+        "ColumnB": {
+            "Type": "DateTime",
+            "Optional": true
+        },
+        "ColumnC": {
+            "Type": "Boolean"
         }
-    ]
+    },
+    "YourTable": {
+        "ColumnA": {
+            "Type": "String"
+        },
+        "ColumnB": {
+            "Type": "DateTime"
+        }
+    }
 }


### PR DESCRIPTION
Converting from Json.NET's JToken into an F# DU allows us to have much shorter table schema JSON, and we could use it to change the blob static schema format to be convenient dynamic JSON.