### PR TITLE
Change static blob schema format to JSON

### DIFF
--- a/FSharp.Azure.StorageTypeProvider.sln
+++ b/FSharp.Azure.StorageTypeProvider.sln
@@ -27,6 +27,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "content", "content", "{15350981-90B9-44A0-B356-776735ACC7F1}"
 	ProjectSection(SolutionItems) = preProject
 		docs\content\blobs.fsx = docs\content\blobs.fsx
+		docs\content\BlobSchema.json = docs\content\BlobSchema.json
 		docs\content\index.fsx = docs\content\index.fsx
 		docs\content\queues.fsx = docs\content\queues.fsx
 		docs\content\quickstart.fsx = docs\content\quickstart.fsx

--- a/docs/content/BlobSchema.json
+++ b/docs/content/BlobSchema.json
@@ -1,0 +1,10 @@
+﻿{
+    "samples": {
+        "file1.txt": null,
+        "file2.txt": null,
+        "file3.txt": null,
+        "folder": { "childFile.txt": null },
+        "folder2": { "child": { "descedant4.txt": null } },
+        "random": { "file.txt": null }
+    }
+}

--- a/docs/content/BlobSchema.json
+++ b/docs/content/BlobSchema.json
@@ -3,8 +3,8 @@
         "file1.txt": null,
         "file2.txt": null,
         "file3.txt": null,
-        "folder": { "childFile.txt": null },
-        "folder2": { "child": { "descedant4.txt": null } },
-        "random": { "file.txt": null }
+        "folder/": { "childFile.txt": null },
+        "folder2/": { "child/": { "descedant4.txt": null } },
+        "random/": { "file.txt": null }
     }
 }

--- a/docs/content/BlobSchema.txt
+++ b/docs/content/BlobSchema.txt
@@ -1,6 +1,0 @@
-﻿samples@file1.txt
-samples@file2.txt
-samples@file3.txt
-samples@folder/childFile.txt
-samples@folder2/child/descedant4.txt
-random@file.txt

--- a/docs/content/blobs.fsx
+++ b/docs/content/blobs.fsx
@@ -24,7 +24,7 @@ page and block blobs.
 (*** define-output: blobStats ***)
 let container = Azure.Containers.samples
 let theBlob = container.``folder/``.``childFile.txt``
-printfn "Blob '%s' is %d bytes big." theBlob.Name theBlob.Size
+printfn "Blob '%s' is %d bytes big." theBlob.Name (theBlob.Size())
 (*** include-output: blobStats ***)
 
 (** 
@@ -48,7 +48,7 @@ let totalSize =
       container.``file2.txt``
       container.``file3.txt``
       container.``sample.txt`` ]
-    |> List.sumBy(fun blob -> blob.Size)
+    |> List.sumBy(fun blob -> blob.Size())
 
 printfn "These files take up %d bytes." totalSize
 (*** include-output: sumOfSizes ***)
@@ -118,26 +118,26 @@ printfn "finished reading all lines"
 
 ## Offline development
 In addition to using the Azure Storage Emulator, you can also simply provide the type provider
-with a text file containing the list of blob containers, folders and files. This is particularly
+with a JSON file containing the list of blob containers, folders and files. This is particularly
 useful within the context of a CI process, or when you know a specific "known good" structure of
 blobs within a storage account.
 
 You can still access the blobs using the compile-time storage connection string if provided,
 or override as normal at runtime.
 
-**Note that Tables and Queues still require a valid compile-time storage connection string!**
+**Note that Queues still require a valid compile-time storage connection string!**
 *)
 
-type BlobSchema = AzureTypeProvider<blobSchema = "BlobSchema.txt">
+type BlobSchema = AzureTypeProvider<blobSchema = "BlobSchema.json">
 let fileFromSchema = BlobSchema.Containers.samples.``file3.txt``
 
 (**
-The contents of `BlobSchema.txt` looks as follows, using the format `{container}@{folder}/{folder}/../{file}`: -
+The contents of `BlobSchema.json` looks as follows. Note that folder names must end with a forward slash: -
 
 *)
 
 (*** define-output: blobSchema ***)
-IO.File.ReadAllLines "BlobSchema.txt" |> Array.iter (printfn "%s")
+IO.File.ReadAllLines "BlobSchema.json" |> Array.iter (printfn "%s")
 
 (*** include-output: blobSchema ***)
 

--- a/docs/content/release-notes.md
+++ b/docs/content/release-notes.md
@@ -67,3 +67,6 @@
 * Upgrade to F# 4.0
 * Upgrade to .NET452
 * Support for static blob schemas
+
+### 1.8.1 - ???
+* Better support for programmatic blob access

--- a/src/FSharp.Azure.StorageTypeProvider/Blob/StaticSchema.fs
+++ b/src/FSharp.Azure.StorageTypeProvider/Blob/StaticSchema.fs
@@ -19,10 +19,11 @@ let rec buildBlobItem prevPath (name:string, item:Json.Json) =
 let buildBlobSchema (json:Json.Json) =
     json.AsObject |> Array.map (fun (containerName, container) ->
         { Name = containerName
-          Contents = lazy (
-            match container with
-            | Json.ObjectOrNull o -> o |> Seq.map (buildBlobItem "")
-            | _ -> failInvalidJson()) })
+          Contents =
+              lazy
+                  (match container with
+                   | Json.ObjectOrNull o -> o |> Seq.map (buildBlobItem "")
+                   | _ -> failInvalidJson()) })
     |> Array.toList
 
 let createSchema resolutionFolder path =

--- a/src/FSharp.Azure.StorageTypeProvider/Blob/StaticSchema.fs
+++ b/src/FSharp.Azure.StorageTypeProvider/Blob/StaticSchema.fs
@@ -6,13 +6,12 @@ open Microsoft.WindowsAzure.Storage.Blob
 open Newtonsoft.Json.Linq
 open System.IO
 
-let rec buildBlobItem prevPath (name, item:Json.Json) =
-    match item with
-    | Json.Null -> Blob (prevPath + name, name, BlobType.BlockBlob, None)
-    | Json.Object o ->
-        let folderName = name + "/"
-        let path = prevPath + folderName
-        Folder (path, folderName, lazy (o |> Array.map (buildBlobItem path)))
+let rec buildBlobItem prevPath (name:string, item:Json.Json) =
+    match name.EndsWith "/", item with
+    | false, Json.ObjectOrNull _ -> Blob (prevPath + name, name, BlobType.BlockBlob, None)
+    | true , Json.ObjectOrNull o ->
+        let path = prevPath + name
+        Folder (path, name, lazy (o |> Array.map (buildBlobItem path)))
     | _ -> failwith "Invalid JSON structure in static blob schema."
 
 let buildBlobSchema (json:Json.Json) =

--- a/src/FSharp.Azure.StorageTypeProvider/Blob/StaticSchema.fs
+++ b/src/FSharp.Azure.StorageTypeProvider/Blob/StaticSchema.fs
@@ -3,40 +3,22 @@
 open BlobRepository
 open FSharp.Azure.StorageTypeProvider.Configuration
 open Microsoft.WindowsAzure.Storage.Blob
-open System
+open Newtonsoft.Json.Linq
 open System.IO
 
-let private splitOn (c:char) (value:string) = value.Split c
+let rec buildBlobItem prevPath (name, item:Json.Json) =
+    match item with
+    | Json.Null -> Blob (prevPath + name, name, BlobType.BlockBlob, None)
+    | Json.Object o ->
+        let folderName = name + "/"
+        let path = prevPath + folderName
+        Folder (path, folderName, lazy (o |> Array.map (buildBlobItem path)))
+    | _ -> failwith "Invalid JSON structure in static blob schema."
 
-let private pathsToContainerItems paths =   
-    let rec toFileTrees prevPath childPaths = 
-        childPaths
-        |> Array.groupBy (function
-            | [] | [ "" ] -> None
-            | [ fileName ] -> Some (fileName, true)
-            | dirName :: _ -> Some (dirName, false))
-        |> Array.choose (function (Some k, v) -> Some (k, v) | _ -> None)
-        |> Array.map (fun ((name, isFile), childPaths) ->
-            if isFile then Blob (prevPath + name, name, BlobType.BlockBlob, None)
-            else
-                let folderName = name + "/"
-                let subPaths = childPaths |> Array.map List.tail
-                let path = prevPath + folderName
-                Folder (path, folderName, lazy (toFileTrees path subPaths |> Seq.toArray)))
-
-    toFileTrees "" paths
-
-let private schemaLinesToContainers lines =
-    lines
-    |> Seq.toArray
-    |> Array.map (fun line ->
-        match line |> splitOn '@' with
-        | [| container; path |] -> (container, path)
-        | _ -> failwith (sprintf "Invalid blob path in static schema: %s" line))
-    |> Array.groupBy fst
-    |> Array.map (fun (containerName, paths) ->
+let buildBlobSchema (json:Json.Json) =
+    json.AsObject |> Array.map (fun (containerName, container) ->
         { Name = containerName
-          Contents = lazy (paths |> Array.map (snd >> splitOn '/' >> Array.toList) |> pathsToContainerItems |> Array.toSeq) })
+          Contents = lazy (container.AsObject |> Seq.map (buildBlobItem "")) })
     |> Array.toList
 
 let createSchema resolutionFolder path =
@@ -48,8 +30,10 @@ let createSchema resolutionFolder path =
         | Some file ->
             try
             file
-            |> File.ReadAllLines
-            |> schemaLinesToContainers
+            |> File.ReadAllText
+            |> JToken.Parse
+            |> Json.ofJToken
+            |> buildBlobSchema
             |> Success
             with ex -> Failure ex)
     |> defaultArg <| Success []

--- a/src/FSharp.Azure.StorageTypeProvider/Shared.fs
+++ b/src/FSharp.Azure.StorageTypeProvider/Shared.fs
@@ -40,11 +40,11 @@ module Json =
         | Object of (string * Json)[]
         | Array of Json[]
         | Null  
-        member this.AsString = match this with Json.String s -> s | _ -> failwith "Not a string"
-        member this.AsNumber = match this with Json.Number s -> s | _ -> failwith "Not a number"
-        member this.AsBoolean = match this with Json.Boolean b -> b | _ -> failwith "Not a boolean"
-        member this.AsObject = match this with Json.Object o -> o | _ -> failwith "Not an object"
-        member this.AsArray = match this with Json.Array o -> o | _ -> failwith "Not an array"
+        member this.AsString = match this with Json.String s -> s | _ -> failwith "Expected a JSON string"
+        member this.AsNumber = match this with Json.Number s -> s | _ -> failwith "Expected a JSON number"
+        member this.AsBoolean = match this with Json.Boolean b -> b | _ -> failwith "Expected a JSON boolean"
+        member this.AsObject = match this with Json.Object o -> o | _ -> failwith "Expected a JSON object"
+        member this.AsArray = match this with Json.Array o -> o | _ -> failwith "Expected a JSON array"
         member this.GetProperty key = this.AsObject |> Array.find (fst >> (=) key) |> snd
         member this.TryGetProperty key =
             match this with Json.Object o -> Some o | _ -> None

--- a/src/FSharp.Azure.StorageTypeProvider/Shared.fs
+++ b/src/FSharp.Azure.StorageTypeProvider/Shared.fs
@@ -66,3 +66,9 @@ module Json =
         | :? JObject as o -> o.Properties() |> Seq.map (fun p -> p.Name, ofJToken p.Value) |> Seq.toArray |> Json.Object
         | :? JArray as a -> a.Values() |> Seq.map ofJToken |> Seq.toArray |> Json.Array
         | v -> failwithf "Cannot convert JSON type %s" (v.GetType().FullName)
+
+    /// Match an Object and treat Null as an empty Object
+    let (|ObjectOrNull|_|) = function
+        | Json.Object o -> Some o
+        | Json.Null -> Some [||]
+        | _ -> None

--- a/tests/IntegrationTests/BlobSchema.json
+++ b/tests/IntegrationTests/BlobSchema.json
@@ -1,15 +1,21 @@
 ﻿{
-	"samples": {
-		"file1.txt": null,
-		"file2.txt": null,
-		"file3.txt": null,
-		"folder": { "childFile.txt": null },
-		"folder2": {
-			"child": { "descedant4.txt": null }
-		}
-	},
-	"random": {
-		"file.txt": null,
-		"folder": { "emptyFolder": {} }
-	}
+    "samples": {
+        "file1.txt": null,
+        "file2.txt": null,
+        "file3.txt": null,
+        "folder/": {
+            "childFile.txt": null
+        },
+        "folder2/": {
+            "child/": {
+                "descendant4.txt": null
+            }
+        }
+    },
+    "random": {
+        "file.txt": null,
+        "folder/": {
+            "emptyFolder/": null
+        }
+    }
 }

--- a/tests/IntegrationTests/BlobSchema.json
+++ b/tests/IntegrationTests/BlobSchema.json
@@ -17,5 +17,6 @@
         "folder/": {
             "emptyFolder/": null
         }
-    }
+    },
+    "emptyContainer": {}
 }

--- a/tests/IntegrationTests/BlobSchema.json
+++ b/tests/IntegrationTests/BlobSchema.json
@@ -1,0 +1,15 @@
+﻿{
+	"samples": {
+		"file1.txt": null,
+		"file2.txt": null,
+		"file3.txt": null,
+		"folder": { "childFile.txt": null },
+		"folder2": {
+			"child": { "descedant4.txt": null }
+		}
+	},
+	"random": {
+		"file.txt": null,
+		"folder": { "emptyFolder": {} }
+	}
+}

--- a/tests/IntegrationTests/BlobSchema.txt
+++ b/tests/IntegrationTests/BlobSchema.txt
@@ -1,7 +1,0 @@
-﻿samples@file1.txt
-samples@file2.txt
-samples@file3.txt
-samples@folder/childFile.txt
-samples@folder2/child/descedant4.txt
-random@file.txt
-random@folder/emptyFolder/

--- a/tests/IntegrationTests/BlobUnitTests.fs
+++ b/tests/IntegrationTests/BlobUnitTests.fs
@@ -9,7 +9,7 @@ open Expecto
 
 type Local = AzureTypeProvider<"DevStorageAccount", "">
 
-type BlobSchema = AzureTypeProvider<blobSchema = "BlobSchema.txt">
+type BlobSchema = AzureTypeProvider<blobSchema = "BlobSchema.json">
 
 let container = Local.Containers.samples
 [<Tests>]

--- a/tests/IntegrationTests/BlobUnitTests.fs
+++ b/tests/IntegrationTests/BlobUnitTests.fs
@@ -137,6 +137,10 @@ let staticSchemaTests =
         testCase "Compiles with folder-only paths" (fun _ ->
             BlobSchema.Containers.random.``folder/``.``emptyFolder/``
             |> ignore) //compiles!
+
+        testCase "Compiles with empty container" (fun _ ->
+            BlobSchema.Containers.emptyContainer
+            |> ignore) //compiles!
     ]
 
 [<Tests>]

--- a/tests/IntegrationTests/IntegrationTests.fsproj
+++ b/tests/IntegrationTests/IntegrationTests.fsproj
@@ -55,7 +55,7 @@
     <Compile Include="TableUnitTests.fs" />
     <Compile Include="Program.fs" />
     <None Include="ResetTestData.fsx" />
-    <Content Include="BlobSchema.txt" />
+    <Content Include="BlobSchema.json" />
     <None Include="paket.references" />
     <None Include="app.config" />
   </ItemGroup>


### PR DESCRIPTION
I'm not 100% sure about the JSON format here. This is the most concise way I could think of to represent a directory structure with only the folder/file names. However, it does mean that file names are object keys with a null value. Is there a different format preferred?

```json
{
    "samples": {
        "file1.txt": null,
        "file2.txt": null,
        "file3.txt": null,
        "folder": { "childFile.txt": null },
        "folder2": {
            "child": { "descedant4.txt": null }
        }
    },
    "random": {
        "file.txt": null,
        "folder": { "emptyFolder": {} }
    }
}
```

Once we're happy with the format I'll add documentation to this PR.