### PR TITLE
Update quickstart.fsx

### DIFF
--- a/docs/content/quickstart.fsx
+++ b/docs/content/quickstart.fsx
@@ -20,7 +20,7 @@ Connecting to Azure
 
 Connecting to your storage account is simple.
 
-From within a script, first ``#load "AzureStorageProvider.fsx"`` to reference all dependencies.
+From within a script, first ``#load "StorageTypeProvider.fsx"`` to reference all dependencies.
 Then, you can generate a type for a storage account simply by providing your Azure
 account credentials via a number of ways.
 


### PR DESCRIPTION
Documentation currently refers to "AzureStorageProvider.fsx" but from looking at the Nuget package files, I think the file referenced should be "StorageTypeProvider.fsx"